### PR TITLE
Changed methods date_sunrise() and date_sunset() to date_sun_info()

### DIFF
--- a/src/Sun.php
+++ b/src/Sun.php
@@ -31,12 +31,11 @@ class Sun
     {
         $onDay = $onDay ?? Carbon::now();
 
-        $sunriseTimestamp = date_sunrise(
+        $sunriseTimestamp = date_sun_info(
             (int)$onDay->timestamp,
-            SUNFUNCS_RET_TIMESTAMP,
             $this->lat,
             $this->lng
-        );
+        )['sunrise'];
 
         return Carbon::createFromTimestamp($sunriseTimestamp);
     }
@@ -58,12 +57,11 @@ class Sun
     {
         $onDay = $onDay ?? Carbon::now();
 
-        $sunsetTimestamp = date_sunset(
+        $sunsetTimestamp = date_sun_info(
             (int)$onDay->timestamp,
-            SUNFUNCS_RET_TIMESTAMP,
             $this->lat,
             $this->lng
-        );
+        )['sunset'];
 
         return Carbon::createFromTimestamp($sunsetTimestamp);
     }


### PR DESCRIPTION
I changed methods `date_sunrise()` and `date_sunset()` to `date_sun_info()` 
due to PHP 8.1 deprecations (https://wiki.php.net/rfc/deprecations_php_8_1)